### PR TITLE
Fix `segment_count` not properly moved onto device

### DIFF
--- a/RWKV-v4neo/src/model.py
+++ b/RWKV-v4neo/src/model.py
@@ -1024,7 +1024,7 @@ class RWKV(L.LightningModule):
                     # ---
                     # we map it to be a tensor, instead of the int directly, as this is more reliable across certain versions of torch/lightning
                     # https://discord.com/channels/992359628979568762/1148755392638234697/1148821863749931008
-                    forward_segment_count  = self.trainer.strategy.reduce(torch.Tensor([segment_count]).to(torch.int), reduce_op="max")
+                    forward_segment_count  = self.trainer.strategy.reduce(torch.Tensor([segment_count]).to(dtype=torch.int, device=cur_device), reduce_op="max")
                     
                     # Convert to int, if its a torch tensor
                     if isinstance(forward_segment_count, torch.Tensor):

--- a/RWKV-v5-beta2/src/model.py
+++ b/RWKV-v5-beta2/src/model.py
@@ -1136,7 +1136,7 @@ class RWKV(L.LightningModule):
                     # ---
                     # we map it to be a tensor, instead of the int directly, as this is more reliable across certain versions of torch/lightning
                     # https://discord.com/channels/992359628979568762/1148755392638234697/1148821863749931008
-                    forward_segment_count  = self.trainer.strategy.reduce(torch.Tensor([segment_count]).to(torch.int), reduce_op="max")
+                    forward_segment_count  = self.trainer.strategy.reduce(torch.Tensor([segment_count]).to(dtype=torch.int, device=cur_device), reduce_op="max")
                     
                     # Convert to int, if its a torch tensor
                     if isinstance(forward_segment_count, torch.Tensor):

--- a/RWKV-v5/src/model.py
+++ b/RWKV-v5/src/model.py
@@ -1151,7 +1151,7 @@ class RWKV(L.LightningModule):
                     # ---
                     # we map it to be a tensor, instead of the int directly, as this is more reliable across certain versions of torch/lightning
                     # https://discord.com/channels/992359628979568762/1148755392638234697/1148821863749931008
-                    forward_segment_count  = self.trainer.strategy.reduce(torch.Tensor([segment_count]).to(torch.int), reduce_op="max")
+                    forward_segment_count  = self.trainer.strategy.reduce(torch.Tensor([segment_count]).to(dtype=torch.int, device=cur_device), reduce_op="max")
                     
                     # Convert to int, if its a torch tensor
                     if isinstance(forward_segment_count, torch.Tensor):


### PR DESCRIPTION
Running the infctx trainer on one VM with CUDA 11.6 and a Runpod VM with CUDA 11.8 resulted in errors due to a tensor being reduced across GPUs not being moved to the current device upon its creation. This should hopefully fix that while not breaking anything for those who didn't get this error.