### PR TITLE
Fix trie-tokenizer decoding

### DIFF
--- a/RWKV-v5/src/dataflow/trie_tokenizer.py
+++ b/RWKV-v5/src/dataflow/trie_tokenizer.py
@@ -96,7 +96,7 @@ class TRIE_TOKENIZER():
         return self.encodeBytes(src.encode("utf-8"))
 
     def decode(self, tokens):
-        return self.decodeBytes(tokens).decode('utf-8')
+        return self.decodeBytes(tokens).decode('utf-8', errors='replace')
 
     def get_vocab_size(self):
         return self.vocab_size
@@ -108,7 +108,7 @@ class TRIE_TOKENIZER():
         for i in tokens:
             s = self.idx2token[i]
             try:
-                s = s.decode('utf-8')
+                s = s.decode('utf-8', errors='replace')
             except:
                 pass
             print(f'{repr(s)}{i}', end=' ')

--- a/RWKV-v6/src/dataflow/trie_tokenizer.py
+++ b/RWKV-v6/src/dataflow/trie_tokenizer.py
@@ -96,7 +96,7 @@ class TRIE_TOKENIZER():
         return self.encodeBytes(src.encode("utf-8"))
 
     def decode(self, tokens):
-        return self.decodeBytes(tokens).decode('utf-8')
+        return self.decodeBytes(tokens).decode('utf-8', errors='replace')
 
     def get_vocab_size(self):
         return self.vocab_size
@@ -108,7 +108,7 @@ class TRIE_TOKENIZER():
         for i in tokens:
             s = self.idx2token[i]
             try:
-                s = s.decode('utf-8')
+                s = s.decode('utf-8', errors='replace')
             except:
                 pass
             print(f'{repr(s)}{i}', end=' ')


### PR DESCRIPTION
I was getting this error, and the updated code replaces un-decodable bytes with a unicode question mark:

```
src/dataflow/trie_tokenizer.py", line 99, in decode
    return self.decodeBytes(tokens).decode('utf-8')
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'utf-8' codec can't decode bytes in position 0-1: unexpected end of data
```